### PR TITLE
Fix the example page in pr-answer 

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 
       <p>This is a repository for the WebRTC Javascript code samples. The source for these samples is available at <a href="https://github.com/webrtc/samples" title="View GitHub repository for these files">github.com/webrtc/samples</a>.</p>
 
-      <p>Some of the samples use new browser features. They may only work in <a href="https://www.google.com/chrome/browser/canary.html" title="Download Chrome Canary">Chrome Canary</a>, <a href="http://www.mozilla.org/firefox/beta/" title="Download Firefox Beta">Firefox Beta</a> or Microsoft Edge (available with Windows 10), and may require flags to be set.</p>
+      <p>Some of the samples use new browser features. They may only work in <a href="https://www.google.com/chrome/browser/canary.html" title="Download Chrome Canary">Chrome Canary</a>, <a href="http://www.mozilla.org/firefox/beta/" title="Download Firefox Beta">Firefox Beta</a>, Microsoft Edge (available with Windows 10) or Safari (supporting WebRTC since High Sierra) and may require flags to be set.</p>
 
       <p>Most of the samples use <a href="https://github.com/webrtc/adapter">adapter.js</a>, a shim to insulate apps from spec changes and prefix differences. (In fact, the standards and protocols used for WebRTC implementations are highly stable, and there are only a few prefixed names. For full interop information, see <a href="http://www.webrtc.org/web-apis/interop">webrtc.org/web-apis/interop</a>.)</p>
 

--- a/src/content/devices/input-output/index.html
+++ b/src/content/devices/input-output/index.html
@@ -65,7 +65,7 @@
       <label for="videoSource">Video source: </label><select id="videoSource"></select>
     </div>
 
-    <video id="video" autoplay></video>
+    <video id="video" playsinline autoplay></video>
 
     <p class="small"><b>Note:</b> If you hear a reverb sound your microphone is picking up the output of your speakers/headset, lower the volume and/or move the microphone further away from your speakers/headset.</p>
 

--- a/src/content/getusermedia/resolution/index.html
+++ b/src/content/getusermedia/resolution/index.html
@@ -84,6 +84,7 @@
       <button id="hd">HD</button>
       <button id="full-hd">Full HD</button>
       <button id="fourK">4K</button>
+      <button id="eightK">8K</button>
     </div>
 
     <div id="videoblock">
@@ -92,7 +93,7 @@
       <video id="gum-res-local" autoplay></video>
       <div id="width">
         <label>Width <span></span>px:</label>
-        <input type="range" min="0" max="4096" value="0">
+        <input type="range" min="0" max="7680" value="0">
       </div>
       <input id="sizelock" type="checkbox">Lock video size<br>
       <input id="aspectlock" type="checkbox">Lock aspect ratio<br>

--- a/src/content/getusermedia/resolution/js/main.js
+++ b/src/content/getusermedia/resolution/js/main.js
@@ -17,6 +17,7 @@ var qvgaButton = document.querySelector('#qvga');
 var hdButton = document.querySelector('#hd');
 var fullHdButton = document.querySelector('#full-hd');
 var fourKButton = document.querySelector('#fourK');
+var eightKButton = document.querySelector('#eightK');
 
 var videoblock = document.querySelector('#videoblock');
 var messagebox = document.querySelector('#errormessage');
@@ -49,6 +50,10 @@ fourKButton.onclick = function() {
   getMedia(fourKConstraints);
 };
 
+eightKButton.onclick = function() {
+  getMedia(eightKConstraints);
+};
+
 var qvgaConstraints = {
   video: {width: {exact: 320}, height: {exact: 240}}
 };
@@ -67,6 +72,10 @@ var fullHdConstraints = {
 
 var fourKConstraints = {
   video: {width: {exact: 4096}, height: {exact: 2160}}
+};
+
+var eightKConstraints = {
+  video: {width: {exact: 7680}, height: {exact: 4320}}
 };
 
 function gotStream(mediaStream) {

--- a/src/content/peerconnection/pc1/js/main.js
+++ b/src/content/peerconnection/pc1/js/main.js
@@ -234,5 +234,4 @@ function hangup() {
   pc2 = null;
   hangupButton.disabled = true;
   callButton.disabled = false;
-  pc1.getStats(); // just to have something testing getstats-after-close.
 }

--- a/src/content/peerconnection/states/index.html
+++ b/src/content/peerconnection/states/index.html
@@ -35,7 +35,7 @@
 
     <h1><a href="//webrtc.github.io/samples/" title="WebRTC samples homepage">WebRTC samples</a> <span>Peer connection: states</span></h1>
 
-    <video id="video1" autoplay></video>
+    <video id="video1" autoplay muted></video>
     <video id="video2" autoplay></video>
 
     <div id="buttons">


### PR DESCRIPTION
**Description**
Disabled the call button when there is an existing call. 

**Purpose**
Due to this had some javascript errors. By disabling this button we can avoid such errors. 

P.S: Use case of Call and Accept button needs a review. [causing javascript errors] #986
https://github.com/webrtc/samples/issues/986